### PR TITLE
[codex] Fix time dry-run handling

### DIFF
--- a/cli/src/cli/commands/time_entry.rs
+++ b/cli/src/cli/commands/time_entry.rs
@@ -81,15 +81,6 @@ fn log(
         ));
     }
 
-    let db_path = resolve_db_path(db_path.map(|p| p.as_path())).ok_or(Error::NotInitialized)?;
-    if !db_path.exists() {
-        return Err(Error::NotInitialized);
-    }
-
-    let actor = actor.map(ToString::to_string).unwrap_or_else(default_actor);
-    let mut storage = SqliteStorage::open(&db_path)?;
-    let project_path = resolve_project_path(&storage, None)?;
-
     // Validate and default date
     let work_date = match &args.date {
         Some(d) => {
@@ -98,6 +89,46 @@ fn log(
         }
         None => chrono::Local::now().format("%Y-%m-%d").to_string(),
     };
+
+    if crate::is_dry_run() {
+        if json {
+            let output = serde_json::json!({
+                "dry_run": true,
+                "action": "log_time_entry",
+                "hours": args.hours,
+                "description": args.description,
+                "work_date": work_date,
+                "period": args.period,
+                "issue": args.issue,
+            });
+            println!("{}", serde_json::to_string(&output)?);
+        } else {
+            let period_str = args
+                .period
+                .as_deref()
+                .map(|p| format!(" [{p}]"))
+                .unwrap_or_default();
+            let issue_str = args
+                .issue
+                .as_deref()
+                .map(|i| format!(" (issue: {i})"))
+                .unwrap_or_default();
+            println!(
+                "Would log {:.1}hrs  {}  {work_date}{period_str}{issue_str}",
+                args.hours, args.description
+            );
+        }
+        return Ok(());
+    }
+
+    let db_path = resolve_db_path(db_path.map(|p| p.as_path())).ok_or(Error::NotInitialized)?;
+    if !db_path.exists() {
+        return Err(Error::NotInitialized);
+    }
+
+    let actor = actor.map(ToString::to_string).unwrap_or_else(default_actor);
+    let mut storage = SqliteStorage::open(&db_path)?;
+    let project_path = resolve_project_path(&storage, None)?;
 
     // Resolve issue short ID to full ID if provided
     let issue_id = if let Some(ref issue_ref) = args.issue {
@@ -412,6 +443,26 @@ fn update(
         validate_status(s)?;
     }
 
+    if crate::is_dry_run() {
+        if json {
+            let output = serde_json::json!({
+                "dry_run": true,
+                "action": "update_time_entry",
+                "id": args.id,
+                "hours": args.hours,
+                "description": args.description,
+                "period": args.period,
+                "issue": args.issue,
+                "date": args.date,
+                "status": args.status,
+            });
+            println!("{}", serde_json::to_string(&output)?);
+        } else {
+            println!("Would update time entry: {}", args.id);
+        }
+        return Ok(());
+    }
+
     let db_path = resolve_db_path(db_path.map(|p| p.as_path())).ok_or(Error::NotInitialized)?;
     if !db_path.exists() {
         return Err(Error::NotInitialized);
@@ -471,6 +522,20 @@ fn update(
 }
 
 fn delete(id: &str, db_path: Option<&PathBuf>, actor: Option<&str>, json: bool) -> Result<()> {
+    if crate::is_dry_run() {
+        if json {
+            let output = serde_json::json!({
+                "dry_run": true,
+                "action": "delete_time_entry",
+                "id": id,
+            });
+            println!("{}", serde_json::to_string(&output)?);
+        } else {
+            println!("Would delete time entry: {id}");
+        }
+        return Ok(());
+    }
+
     let db_path = resolve_db_path(db_path.map(|p| p.as_path())).ok_or(Error::NotInitialized)?;
     if !db_path.exists() {
         return Err(Error::NotInitialized);
@@ -502,6 +567,24 @@ fn invoice(
     actor: Option<&str>,
     json: bool,
 ) -> Result<()> {
+    if crate::is_dry_run() {
+        if json {
+            let output = serde_json::json!({
+                "dry_run": true,
+                "action": "invoice_time_entries",
+                "period": period,
+                "from_status": from,
+                "to_status": "invoiced",
+            });
+            println!("{}", serde_json::to_string(&output)?);
+        } else {
+            println!(
+                "Would mark {from} entries as invoiced for period: {period}"
+            );
+        }
+        return Ok(());
+    }
+
     let db_path = resolve_db_path(db_path.map(|p| p.as_path())).ok_or(Error::NotInitialized)?;
     if !db_path.exists() {
         return Err(Error::NotInitialized);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -26,13 +26,18 @@ fn preprocess_args(args: impl Iterator<Item = String>) -> Vec<String> {
                     // project update, plan update, checkpoint restore,
                     // session resume/delete, memory delete/get
         "--name",   // session start, session rename
-        "--hours",  // time log
     ];
 
     // --path is positional in: project create
     // --path is NAMED in: skills install
     if subcommand.as_deref() == Some("project") && subsubcommand.as_deref() == Some("create") {
         aliases.push("--path");
+    }
+
+    // --hours is positional in: time log
+    // --hours is a NAMED field in: time update
+    if subcommand.as_deref() == Some("time") && subsubcommand.as_deref() == Some("log") {
+        aliases.push("--hours");
     }
 
     // --key is positional in: save, update, delete, tag, memory save/delete/get


### PR DESCRIPTION
## What changed
- Stops `time log --dry-run`, `time update --dry-run`, `time delete --dry-run`, and `time invoice --dry-run` before they mutate storage.
- Keeps validation for obvious bad input before the dry-run preview.
- Makes the CLI argument preprocessor strip `--hours` only for `time log`, so `time update <id> --hours <n>` reaches Clap as a named field.

## Why
While setting up SaveContext for time tracking, two CLI issues showed up:
- `time log --dry-run` still created a persisted time entry.
- `time update <id> --hours 1` was misparsed because `--hours` was globally rewritten as a positional alias.

## Verification
- `cargo test --manifest-path cli/Cargo.toml --quiet`
- Isolated temp DB repro with source CLI:
  - `time log 0.25 "dry run should not write" --period TEST-DRY-RUN --dry-run --json`
  - `time list --period TEST-DRY-RUN --json` returned `count: 0`
  - created one real entry at `0.25` hours
  - `time update <entry> --hours 1 --dry-run --json` parsed successfully
  - final list still showed the real entry at `0.25` hours