### PR TITLE
[codex] Fix dashboard standalone packaging

### DIFF
--- a/dashboard/next.config.ts
+++ b/dashboard/next.config.ts
@@ -1,8 +1,10 @@
 import type { NextConfig } from "next";
+import path from "node:path";
 
 const nextConfig: NextConfig = {
   // Local dashboard - reads from ~/.savecontext/data/savecontext.db
   output: 'standalone',
+  outputFileTracingRoot: path.join(process.cwd(), ".."),
 };
 
 export default nextConfig;

--- a/server/scripts/npm/fix-pnpm-modules.cjs
+++ b/server/scripts/npm/fix-pnpm-modules.cjs
@@ -15,6 +15,11 @@ const pnpmDir = path.join(nodeModulesDir, '.pnpm');
 // Modules that need fixing (native modules with build artifacts)
 const modulesToFix = ['better-sqlite3', 'bindings', 'file-uri-to-path', 'detect-libc'];
 
+if (!fs.existsSync(pnpmDir)) {
+  console.log('No pnpm module store found in standalone bundle; skipping module fix');
+  process.exit(0);
+}
+
 for (const moduleName of modulesToFix) {
   const stubDir = path.join(nodeModulesDir, moduleName);
 


### PR DESCRIPTION
## What changed
- Sets `outputFileTracingRoot` to the repository root for the dashboard Next.js standalone build.
- Makes `fix-pnpm-modules.cjs` skip gracefully when a standalone bundle does not contain `node_modules/.pnpm` at the expected path.

## Why
While setting up SaveContext from source, `pnpm --filter @savecontext/dashboard build` failed during postbuild packaging:
- Next inferred `/Users/shreyvishen` as the tracing root because of another lockfile outside the repo.
- That produced a standalone tree under absolute path segments instead of `.next/standalone/dashboard`.
- The postbuild copy failed because `.next/standalone/dashboard/.next` did not exist.
- The pnpm module fixer then crashed on a missing `.next/standalone/node_modules/.pnpm` directory.

## Verification
- Reproduced the failure on `main` with `pnpm --filter @savecontext/dashboard build`.
- Removed the failed `.next` output and rebuilt with `pnpm --filter @savecontext/dashboard build`; build completed successfully.
- Smoke-tested generated standalone server with `PORT=3334 HOSTNAME=127.0.0.1 bun dashboard/.next/standalone/dashboard/server.js`.
- Confirmed `http://127.0.0.1:3334/api/projects` responded successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced deployment reliability by implementing module dependency validation checks, which prevent build failures in standalone environments. The system now gracefully handles missing module dependencies.

* **Chores**
  * Updated Next.js build configuration to improve file tracing optimization for standalone deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->